### PR TITLE
Refactor exit logic to use shared parameters from params.h

### DIFF
--- a/src/exits.cxx
+++ b/src/exits.cxx
@@ -3,6 +3,7 @@
 #include "fix.h"
 #include "json.h"
 #include "market.h"
+#include "params.h"
 #include <chrono>
 #include <fstream>
 #include <iostream>
@@ -106,13 +107,13 @@ int main() {
     }
     // Check normal exit conditions using our exit logic
     else {
-      // Create position with take profit (+10%), stop loss (-5%), trailing stop
+      // Create position using shared params from params.h
+      auto levels = calculate_levels(pos.avg_entry_price, default_params);
       auto mock_position = position{
           .entry_price = pos.avg_entry_price,
-          .take_profit = pos.avg_entry_price * 1.10,
-          .stop_loss = pos.avg_entry_price * 0.95,
-          .trailing_stop =
-              pos.avg_entry_price * 0.95 // Start at stop loss level
+          .take_profit = levels.take_profit,
+          .stop_loss = levels.stop_loss,
+          .trailing_stop = levels.trailing_stop,
       };
 
       // Check exit strategy
@@ -120,9 +121,9 @@ int main() {
         should_exit = true;
 
         // Determine which condition triggered
-        if (profit_pct >= 10.0)
+        if (profit_pct >= default_params.take_profit_pct * 100.0)
           exit_reason = "take_profit";
-        else if (profit_pct <= -5.0)
+        else if (profit_pct <= -default_params.stop_loss_pct * 100.0)
           exit_reason = "stop_loss";
         else
           exit_reason = "trailing_stop";


### PR DESCRIPTION
## Summary
Refactored the exit condition logic in `src/exits.cxx` to use centralized trading parameters defined in `params.h` instead of hardcoded values. This improves maintainability and ensures consistent parameter usage across the codebase.

## Key Changes
- Added `#include "params.h"` to access shared parameter definitions
- Replaced hardcoded take profit (+10%) and stop loss (-5%) values with a call to `calculate_levels()` function that uses `default_params`
- Updated exit condition checks to reference `default_params.take_profit_pct` and `default_params.stop_loss_pct` instead of magic numbers
- Simplified position initialization by using the calculated `levels` struct instead of inline calculations

## Implementation Details
- The `calculate_levels()` function now handles all position level calculations based on entry price and shared parameters
- Exit reason determination now dynamically references parameter percentages, making the code more flexible for parameter adjustments
- This change eliminates the need to update hardcoded values in multiple places when trading parameters need to be modified

https://claude.ai/code/session_01MCECyZjE2wZqvJJCYmar3b